### PR TITLE
determine the artifact ID from the travis tag as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,11 @@ git:
 os:
   - linux
 env:
-  - V=0.28.0
+  # TRAVIS_TAG should be set as "<artifactSuffix>--<version>"; otherwise publishing will abort
+  global:
+    - BAZEL=0.28.0
+    - COMPILER_CLI_ARTIFACT_ID="play-routes-compiler-cli_$(awk -F '--' '{print $1}' <<< $TRAVIS_TAG)"
+    - COMPILER_CLI_VERSION="$(awk -F '--' '{print $2}' <<< $TRAVIS_TAG)"
 before_install:
   # Borrowed from rules_scala
   - |
@@ -17,12 +21,12 @@ before_install:
     sudo apt-get update -q
     sudo apt-get install libxml2-utils -y
     OS=linux
-    if [[ $V =~ .*rc[0-9]+.* ]]; then
-      PRE_RC=$(expr "$V" : '\([0-9.]*\)rc.*')
-      RC_PRC=$(expr "$V" : '[0-9.]*\(rc.*\)')
-      URL="https://storage.googleapis.com/bazel/${PRE_RC}/${RC_PRC}/bazel-${V}-installer-${OS}-x86_64.sh"
+    if [[ $BAZEL =~ .*rc[0-9]+.* ]]; then
+      PRE_RC=$(expr "$BAZEL" : '\([0-9.]*\)rc.*')
+      RC_PRC=$(expr "$BAZEL" : '[0-9.]*\(rc.*\)')
+      URL="https://storage.googleapis.com/bazel/${PRE_RC}/${RC_PRC}/bazel-${BAZEL}-installer-${OS}-x86_64.sh"
     else
-      URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
+      URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL}/bazel-${BAZEL}-installer-${OS}-x86_64.sh"
     fi
     wget -nv -O install.sh "${URL}"
     chmod +x install.sh

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -114,7 +114,7 @@ http_archive(
 load("@env_vars_to_bzl_vars//:env_vars_loader.bzl", "load_env_vars")
 load_env_vars(
   name = "env_vars",
-  env_vars = ["TRAVIS_TAG"]
+  env_vars = ["COMPILER_CLI_ARTIFACT_ID", "COMPILER_CLI_VERSION"]
 )
 
 ## For tests

--- a/play-routes-compiler/BUILD.bazel
+++ b/play-routes-compiler/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@rules_scala_annex//rules:scala.bzl", "scala_binary")
 load("@bazel-common//tools/maven:pom_file.bzl", "pom_file")
-load("@env_vars//:env_vars.bzl", "TRAVIS_TAG")
+load("@env_vars//:env_vars.bzl", "COMPILER_CLI_ARTIFACT_ID", "COMPILER_CLI_VERSION")
 
 scala_binary(
   name = "play-routes-compiler",
@@ -15,11 +15,15 @@ scala_binary(
   ],
 )
 
-compiler_cli_version = TRAVIS_TAG if len(TRAVIS_TAG) > 0 else "non-published-SNAPSHOT"
+artifact_id = COMPILER_CLI_ARTIFACT_ID if len(COMPILER_CLI_ARTIFACT_ID) > 0 else "play_routes_compiler_cli"
+version = COMPILER_CLI_VERSION if len(COMPILER_CLI_VERSION) > 0 else "non-published-SNAPSHOT"
 
 pom_file(
   name = "pom",
   targets = [":play-routes-compiler"],
   template_file = "pom.template.xml",
-  substitutions = {"VERSION": compiler_cli_version}
+  substitutions = {
+    "ARTIFACT_ID": artifact_id,
+    "VERSION": version
+    }
 )

--- a/play-routes-compiler/pom.template.xml
+++ b/play-routes-compiler/pom.template.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.lucidchart</groupId>
-  <artifactId>play-routes-compiler-cli</artifactId>
+  <artifactId>ARTIFACT_ID</artifactId>
   <version>VERSION</version>
   <packaging>jar</packaging>
 


### PR DESCRIPTION
tags should be set as `<artifactSuffix>--<version>`

For example, to publish a version of the compiler cli that's compatible with Scala 2.11 and Play 2.5, the tag should be: `2.11--2.5`

To publish a snapshot for this version, the tag should be: `2.11--2.5-SNAPSHOT`