### PR TITLE
Fix deployments to maven

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: required
+sudo: false
 
 # Not technically required but suppresses 'Ruby' in Job status message.
 language: java
@@ -7,7 +7,7 @@ language: java
 git:
   depth: 1
 os:
-  - linux
+  - osx
 env:
   # TRAVIS_TAG should be set as "<artifactSuffix>--<version>"; otherwise publishing will abort
   global:
@@ -17,10 +17,7 @@ env:
 before_install:
   # Borrowed from rules_scala
   - |
-    sysctl kernel.unprivileged_userns_clone=1
-    sudo apt-get update -q
-    sudo apt-get install libxml2-utils -y
-    OS=linux
+    OS=darwin
     if [[ $BAZEL =~ .*rc[0-9]+.* ]]; then
       PRE_RC=$(expr "$BAZEL" : '\([0-9.]*\)rc.*')
       RC_PRC=$(expr "$BAZEL" : '[0-9.]*\(rc.*\)')
@@ -39,7 +36,7 @@ after_success:
   - |
     if [ "$TRAVIS_SECURE_ENV_VARS" == true ] && [ -n "$TRAVIS_TAG" ]; then
       echo "$PGP_SECRET" | base64 --decode | gpg --import
-      bash scripts/publish.sh
+      ./scripts/publish.sh
     else
       echo "Skipped publishing."
       echo "Travis Tag: $TRAVIS_TAG"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -18,8 +18,7 @@ jar -cf "$source_jar" temp/README
 jar -cf "$javadoc_jar" temp/README
 
 # Determine the url to publish to based on whether this is a SNAPSHOT version
-is_snapshot=$(echo "$version" | grep -o "SNAPSHOT" | wc -w)
-if [[ $is_snapshot > 0 ]]; then
+if [[ $version =~ .*SNAPSHOT$ ]]; then
 	url="https://oss.sonatype.org/content/repositories/snapshots"
 else
 	url="https://oss.sonatype.org/service/local/staging/deploy/maven2"


### PR DESCRIPTION
- mv gpg:sign-and-deploy-file fails on CI because it tries to make a GET request to a POST endpoint
    - Solution: sign artifacts first and then deploy them along with their signatures using mvn deploy:deploy-file

- Travis Linux hosts have a bug where inconsinstent IP addresses are used accross requests (travis-ci/travis-ci#9555)
  This led to artifacts being sent form different IP addresses and thus into separate Staging Repositories in Sonatype
    - Solution: use OSX instead of Linux in Travis